### PR TITLE
Fix for ST3

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -1,6 +1,5 @@
 [
   { "keys": ["ctrl+period"], "command": "jasmine_switch_between_code_and_spec", "context" : [
-    { "key": "selector", "operator": "equal", "operand": "source.js", "match_all": true },
-    { "key": "selector", "operator": "equal", "operand": "source.coffee", "match_all": true }
+    { "key": "selector", "operator": "equal", "operand": "source.js", "match_all": true }
   ]} // switch between code and test
 ]

--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -1,5 +1,6 @@
 [
   { "keys": ["ctrl+period"], "command": "jasmine_switch_between_code_and_spec", "context" : [
-    { "key": "selector", "operator": "equal", "operand": "source.js", "match_all": true }
+    { "key": "selector", "operator": "equal", "operand": "source.js", "match_all": true },
+    { "key": "selector", "operator": "equal", "operand": "source.coffee", "match_all": true }
   ]} // switch between code and test
 ]

--- a/run_jasmine.py
+++ b/run_jasmine.py
@@ -1,6 +1,5 @@
 import os
 import re
-import thread
 import subprocess
 import functools
 import time
@@ -31,11 +30,11 @@ class JasmineSwitchBetweenCodeAndSpec(sublime_plugin.TextCommand):
       return JasmineSwitchBetweenCodeAndSpec.BaseFile(file_name)
 
   def is_enabled(self):
-    return self.current_file().possible_alternate_files()
+    return not not self.current_file().possible_alternate_files()
 
   def run(self, args):
     possible_alternates = self.current_file().possible_alternate_files()
-    alternates = self.project_files(lambda(file): file in possible_alternates)
+    alternates = self.project_files(lambda file: file in possible_alternates)
     if alternates:
       self.window().open_file(alternates.pop())
     else:


### PR DESCRIPTION
Sublime Text 3 uses Python 3, which changes the lambda syntax. It also requires is_enabled to have a return type of boolean.
